### PR TITLE
docs: README mention community PyTorch implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,5 @@ python detector.py \
 Add the `--save_video FILENAME` flag to save out the results.
 
 The `--visualize_detector` flag can be used to visualize the output of the detector network. The mask corresponds to the segmentation mask, the colored polygons are fit to this segmentation mask using a set of heuristics. The detector outputs can noisy and are sensitive to size of the stegastamp. Further optimization of the detection network is not explored in this paper.
+
+> For a community PyTorch implementation, see https://github.com/jsrdcht/StegaStamp-pytorch


### PR DESCRIPTION
This PR adds a short note in the README pointing users to a community PyTorch implementation: https://github.com/jsrdcht/StegaStamp-pytorch.\n\nMotivation: users searching for a PyTorch version can easily find an actively maintained implementation while this repo remains TensorFlow-based.\n\nThanks for considering!